### PR TITLE
transform to lowercase using Locale.ROOT

### DIFF
--- a/src/main/java/galena/copperative/config/CommonConfig.java
+++ b/src/main/java/galena/copperative/config/CommonConfig.java
@@ -15,6 +15,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -129,7 +130,7 @@ public class CommonConfig {
             var property = builder.define("enabled", true);
             var targets = ImmutableMap.<OverrideTarget, BooleanSupplier>builder();
             for (OverrideTarget target : OverrideTarget.values()) {
-                var targetProperty = builder.define(target.name().toLowerCase(), true);
+                var targetProperty = builder.define(target.name().toLowerCase(Locale.ROOT), true);
                 targets.put(target, targetProperty::get);
             }
 

--- a/src/main/java/galena/copperative/config/OverwriteEnabledCondition.java
+++ b/src/main/java/galena/copperative/config/OverwriteEnabledCondition.java
@@ -11,6 +11,7 @@ import net.minecraftforge.common.crafting.conditions.IConditionSerializer;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.Nullable;
+import java.util.Locale;
 import java.util.Objects;
 
 public class OverwriteEnabledCondition implements ICondition {
@@ -47,7 +48,7 @@ public class OverwriteEnabledCondition implements ICondition {
         @Override
         public void write(JsonObject json, OverwriteEnabledCondition value) {
             json.addProperty("block", value.key.toString());
-            if (value.target != null) json.addProperty("target", value.target.name().toLowerCase());
+            if (value.target != null) json.addProperty("target", value.target.name().toLowerCase(Locale.ROOT));
         }
 
         @Override

--- a/src/main/java/galena/copperative/data/CLang.java
+++ b/src/main/java/galena/copperative/data/CLang.java
@@ -9,6 +9,7 @@ import net.minecraft.world.level.block.WeatheringCopper;
 import net.minecraftforge.registries.RegistryObject;
 
 import java.util.List;
+import java.util.Locale;
 
 public class CLang extends CLangProvider {
 
@@ -20,7 +21,7 @@ public class CLang extends CLangProvider {
         blocks.forEach(block -> {
             if(block.get() instanceof WeatheringCopper copper && copper.getAge() != WeatheringCopper.WeatherState.UNAFFECTED) {
                 var name = copper.getAge().name();
-                var prefix = name.substring(0, 1).toUpperCase() + name.substring(1).toLowerCase();
+                var prefix = name.substring(0, 1).toUpperCase() + name.substring(1).toLowerCase(Locale.ROOT);
                 addBlock(block, prefix + " " + base);
             } else {
                 addBlock(block, base);

--- a/src/main/java/galena/copperative/data/provider/CItemModelProvider.java
+++ b/src/main/java/galena/copperative/data/provider/CItemModelProvider.java
@@ -15,6 +15,7 @@ import net.minecraftforge.registries.RegistryObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Supplier;
 
 public abstract class CItemModelProvider extends ItemModelProvider {
@@ -151,7 +152,7 @@ public abstract class CItemModelProvider extends ItemModelProvider {
     public String weatherPrefix(Block block) {
         if (block instanceof WeatheringCopper it) {
             var age = it.getAge();
-            if (age != WeatheringCopper.WeatherState.UNAFFECTED) return age.name().toLowerCase() + "_";
+            if (age != WeatheringCopper.WeatherState.UNAFFECTED) return age.name().toLowerCase(Locale.ROOT) + "_";
         }
         return "";
     }

--- a/src/main/java/galena/copperative/index/CBlocks.java
+++ b/src/main/java/galena/copperative/index/CBlocks.java
@@ -149,7 +149,7 @@ public class CBlocks {
 
     public static <B extends Block> CopperSet<B> registerConvertedSet(String name, Supplier<B> targetSupplier, Function<WeatherState, B> function, ResourceKey<CreativeModeTab> tab) {
         var weathered = Stream.of(WeatherState.EXPOSED, WeatherState.WEATHERED, WeatherState.OXIDIZED).<Supplier<B>>map(weatherState -> {
-            String prefix = weatherState.name().toLowerCase() + "_";
+            String prefix = weatherState.name().toLowerCase(Locale.ROOT) + "_";
             return register(prefix + name, () -> function.apply(weatherState), tab);
         }).toList();
         return new CopperSet<>(targetSupplier, weathered);
@@ -164,7 +164,7 @@ public class CBlocks {
         WeatherState[] wStates = WeatherState.values();
         ArrayList<RegistryObject<B>> blocks = new ArrayList<>(4);
         for (final WeatherState weatherState : wStates) {
-            String prefix = weatherState.equals(WeatherState.UNAFFECTED) ? "" : weatherState.name().toLowerCase() + "_";
+            String prefix = weatherState.equals(WeatherState.UNAFFECTED) ? "" : weatherState.name().toLowerCase(Locale.ROOT) + "_";
             Supplier<? extends B> supplier = () -> function.apply(weatherState);
             blocks.add(register(name.apply(prefix), supplier, tab));
         }


### PR DESCRIPTION
closes #19 for 1.20

1) `ResourceLocations` only accept letters matching `[a-zA-Z]`
2)  Transforming to lowercase without the root locale uses the system locale
3) Some locales, like *tr-TR* transform a capital `I` to `ı` instead of `i`