### PR TITLE
Add blocks/items in sorted order to creative tab

### DIFF
--- a/src/main/java/galena/copperative/index/CTabs.java
+++ b/src/main/java/galena/copperative/index/CTabs.java
@@ -1,26 +1,28 @@
 package galena.copperative.index;
 
+import com.mojang.datafixers.util.Pair;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.function.Supplier;
 
 public class CTabs {
 
 
-    private static final HashMap<Supplier<? extends ItemLike>, ResourceKey<CreativeModeTab>> ITEMS_TO_TABS = new HashMap<>();
+    private static final Collection<Pair<Supplier<? extends ItemLike>, ResourceKey<CreativeModeTab>>> ITEMS_TO_TABS = new ArrayList<>();
 
     public static void addToTab(Supplier<? extends ItemLike> supplier, ResourceKey<CreativeModeTab> tab) {
-        ITEMS_TO_TABS.put(supplier, tab);
+        ITEMS_TO_TABS.add(new Pair<>(supplier, tab));
     }
 
     public static void addCreativeTabs(BuildCreativeModeTabContentsEvent event) {
-        ITEMS_TO_TABS.entrySet().stream()
-                .filter(it -> it.getValue().equals(event.getTabKey()))
-                .forEach(it -> event.accept(it.getKey()));
+        ITEMS_TO_TABS.stream()
+                .filter(it -> it.getSecond().equals(event.getTabKey()))
+                .forEach(it -> event.accept(it.getFirst()));
     }
 
 }


### PR DESCRIPTION
not yet figured out how to insert them before blocks/items of minecraft or other mods, but this is not a priority right now.
therefore a partial solution for #28 