### PR TITLE
fixed incompatibility with rechiseled and create (Crashes on Forge Startup)

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -67,3 +67,17 @@ Uniting copper and redstone components as one and expanding on copper as a whole
     versionRange="*"
     ordering="AFTER"
     side="BOTH"
+
+[[dependencies.${mod_id}]]
+    modId="rechiseled"
+    mandatory=false
+    versionRange="*"
+    ordering="BEFORE"
+    side="BOTH"
+
+[[dependencies.${mod_id}]]
+    modId="rechiseledcreate"
+    mandatory=false
+    versionRange="*"
+    ordering="BEFORE"
+    side="BOTH"


### PR DESCRIPTION
rechiseled seems to depend on copperative:copper_bricks for some reason, after adding create AFTER dependency this causes crashes at launch. by putting copperative in between rechiseled and rechiseledcreate this is fixed. Testing with different types of modpacks was not performed, this should be fine though.